### PR TITLE
Change build_data_record to allow for multiple variable_types

### DIFF
--- a/code/envds/envds/daq/sensor.py
+++ b/code/envds/envds/daq/sensor.py
@@ -881,7 +881,7 @@ class Sensor(envdsBase):
 
     def build_data_record(self, meta: bool = False, mode: str = "default") -> dict:
         #TODO: change data_format -> format_version
-
+        # TODO: create record for any number of variable_types
         record = {
             # "time": get_datetime_string(),
             "timestamp": get_datetime_string(),


### PR DESCRIPTION
In the base sensor class, change the build_data_record function to return a data record that includes any number of available variable types. These types can include:

- default/main
- settings
- calibration

The idea is that not everything will be sent every time and the receiving services need to handle the appropriate types