### PR TITLE
creating sensor folder within apps/daq and adding magic250 driver

### DIFF
--- a/code/envds/envds/core.py
+++ b/code/envds/envds/core.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 from logfmter import Logfmter
 
+
 # from typing import Union
 from pydantic import BaseModel
 


### PR DESCRIPTION
This branch was created to
- add a sensor folder within the apps/daq directory
- add a Magic 250 driver to the new sensor folder
- edit the Magic 250 driver to include variable types within the metadata
- edit the Magic 250 driver to include settings / calibration info within the metadata